### PR TITLE
Added encode when updating password

### DIFF
--- a/src/main/java/dev/accessaid/AccessAid/User/service/UserServiceImpl.java
+++ b/src/main/java/dev/accessaid/AccessAid/User/service/UserServiceImpl.java
@@ -57,10 +57,6 @@ public class UserServiceImpl implements UserService {
         newUser.setUsername(signUpRequest.getUsername());
         newUser.setPassword(encoder.encode(signUpRequest.getPassword()));
         userRepository.save(newUser);
-        // User user = new User(null, signUpRequest.getUsername(),
-        // signUpRequest.getEmail(), encoder.encode(signUpRequest.getPassword()));
-        // userRepository.save(user);
-
         return new ResponseEntity<>(new MessageResponse("user was registered correctly"), HttpStatus.CREATED);
     }
 
@@ -105,7 +101,19 @@ public class UserServiceImpl implements UserService {
         if (!userToChange.isPresent()) {
             throw new UserNotFoundException("User not found");
         }
-        return userRepository.save(user);
+
+        User existingUser = userToChange.get();
+        if (user.getEmail() != null) {
+            existingUser.setEmail(user.getEmail());
+        }
+        if (user.getUsername() != null) {
+            existingUser.setUsername(user.getUsername());
+        }
+        if (user.getPassword() != null) {
+            existingUser.setPassword(encoder.encode(user.getPassword()));
+        }
+
+        return userRepository.save(existingUser);
     }
 
     @Override


### PR DESCRIPTION
## TICKET

<!-- Insertar el nombre de la tarea en los corchetes y el link de Trello en los paréntesis -->

- [Arreglar la función changeUser](https://trello.com/c/JRdWyyh4/52-arreglar-la-funci%C3%B3n-changeuser)

## Description

Update the changeUser function in the User entity service to securely store the encrypted password in the database when editing. Additionally, add functionality to update only the fields received in the bodyRequest in the database, whether it's a single field or all fields. The remaining fields remain unchanged.

AS: developer
I Want: the edited password to be securely stored in the database in an encrypted format and to implement functionality to update only the fields received in the bodyRequest in the database.
To: ensure that if the password is changed, it is securely stored in the database using the same hashing technique as during user registration.


